### PR TITLE
fix: 明治より前の日付が指定された場合もエラーにならないようにする

### DIFF
--- a/lib/receiptisan/output/preview/parameter/common.rb
+++ b/lib/receiptisan/output/preview/parameter/common.rb
@@ -74,6 +74,7 @@ module Receiptisan
               # @param month [::Date]
               def from(date)
                 gengou = Util::DateUtil::Gengou.find_by_alphabet(date.jisx0301[0])
+                # 元号が見つからない場合、西暦に fallback する
                 new(
                   code:       gengou&.code,
                   name:       gengou&.name || "西暦",

--- a/lib/receiptisan/output/preview/parameter/common.rb
+++ b/lib/receiptisan/output/preview/parameter/common.rb
@@ -75,11 +75,11 @@ module Receiptisan
               def from(date)
                 gengou = Util::DateUtil::Gengou.find_by_alphabet(date.jisx0301[0])
                 new(
-                  code:       gengou.code,
-                  name:       gengou.name,
-                  short_name: gengou.short_name,
-                  alphabet:   gengou.alphabet,
-                  base_year:  gengou.base_year
+                  code:       gengou&.code,
+                  name:       gengou&.name || "西暦",
+                  short_name: gengou&.short_name || "",
+                  alphabet:   gengou&.alphabet || "",
+                  base_year:  gengou&.base_year || 0
                 )
               end
             end


### PR DESCRIPTION
## Why / 背景

1800年うまれの患者データが渡されるとエラーになってしまう。
現実的にはほぼないが、テスト時などでエラーになって通知がうるさくなると困るため、エラーにならないようにしておきたい。

## What / 変更内容



---


<details>
<summary>Pull Request 作成者へ</summary>

Pull Request のレビューを依頼する際には、円滑なレビューを行うために以下を確認してください。

- アプリケーションコードへの変更の場合、[Release Plan](https://www.notion.so/henry-inc/cc805fd35aea4f5a9b08d515221dee51)を作成しましょう。
  - ただし、顧客案内も動作確認も不要と判断している場合は、リリースプランの作成は不要です。その判断も含めてレビューするため、判断内容をコメントに記載してください。
- 手元で動作確認を行い、問題がないことを確認しましょう。
- [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) を読みましょう。
- 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足しましょう。
- 既存のデータにどのような影響があるかを考慮し、必要があれば補足を記載しましょう。
- どのように動作確認をするか、チームで認識を揃えましょう。必要があれば、検討した内容を Pull Request から辿れるよう、転記やリンクの記載をしましょう。

</details>
