### PR TITLE
fix: Add nkf gem as dependency to suppress warnings

### DIFF
--- a/receiptisan.gemspec
+++ b/receiptisan.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do | spec |
   spec.summary       = 'Library to parse receipt UKE contents'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/yokenzan/receiptisan'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.3.0')
 
   spec.metadata['homepage_uri']    = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
@@ -30,6 +30,8 @@ Gem::Specification.new do | spec |
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency 'dry-cli'
   spec.add_dependency 'month'
+  spec.add_dependency 'nkf'
+  spec.add_dependency 'logger'
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Why / 背景

3.3.5 で動かすと、

```
nkf was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add nkf to your Gemfile or gemspec to silence this warning.
/share/ruby/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```

という warning がでている。

## What / 変更内容

gemspec を更新する。
(ostructはなんか実行環境がおかしいような気がするので見直す。3.3.5で動いているはずなのに /share/ruby/lib/ruby/3.3.0/json を見ているのが謎。）

---


<details>
<summary>Pull Request 作成者へ</summary>

Pull Request のレビューを依頼する際には、円滑なレビューを行うために以下を確認してください。

- アプリケーションコードへの変更の場合、[Release Plan](https://www.notion.so/henry-inc/cc805fd35aea4f5a9b08d515221dee51)を作成しましょう。
  - ただし、顧客案内も動作確認も不要と判断している場合は、リリースプランの作成は不要です。その判断も含めてレビューするため、判断内容をコメントに記載してください。
- 手元で動作確認を行い、問題がないことを確認しましょう。
- [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) を読みましょう。
- 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足しましょう。
- 既存のデータにどのような影響があるかを考慮し、必要があれば補足を記載しましょう。
- どのように動作確認をするか、チームで認識を揃えましょう。必要があれば、検討した内容を Pull Request から辿れるよう、転記やリンクの記載をしましょう。

</details>
