### PR TITLE
fix: 和暦に変換できない日付が入力されるとエラーになる問題を修正

### DIFF
--- a/lib/receiptisan/util/date_util.rb
+++ b/lib/receiptisan/util/date_util.rb
@@ -95,6 +95,12 @@ module Receiptisan
 
           jisx0301 = date.jisx0301
           gengou   = Gengou.find_by_alphabet(jisx0301[0])
+
+          unless gengou
+            text = "西暦#{date.year}年#{date.month}月#{date.day}日"
+            return (zenkaku ? Formatter.to_zenkaku(text) : text).tap { | ret | ret[-3..] = '' if is_month }
+          end
+
           text     = '%s%s年%s月%s日' % [
             gengou.name,
             jisx0301[1, 2],


### PR DESCRIPTION
## Why / 背景

和暦に変換できない日付が入力されると、nil参照でエラーになる

## What / 変更内容

#3 で直したつもりになっていたが、別の場所でも同じ問題が起きていた。

---


<details>
<summary>Pull Request 作成者へ</summary>

Pull Request のレビューを依頼する際には、円滑なレビューを行うために以下を確認してください。

- アプリケーションコードへの変更の場合、[Release Plan](https://www.notion.so/henry-inc/cc805fd35aea4f5a9b08d515221dee51)を作成しましょう。
  - ただし、顧客案内も動作確認も不要と判断している場合は、リリースプランの作成は不要です。その判断も含めてレビューするため、判断内容をコメントに記載してください。
- 手元で動作確認を行い、問題がないことを確認しましょう。
- [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) を読みましょう。
- 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足しましょう。
- 既存のデータにどのような影響があるかを考慮し、必要があれば補足を記載しましょう。
- どのように動作確認をするか、チームで認識を揃えましょう。必要があれば、検討した内容を Pull Request から辿れるよう、転記やリンクの記載をしましょう。

</details>
