### PR TITLE
fix: コメント８０パターンで期待する形式の値がレセプトプレビューに表示されない

### DIFF
--- a/lib/receiptisan/model/receipt_computer/digitalized_receipt/parser/comment_content_builder.rb
+++ b/lib/receiptisan/model/receipt_computer/digitalized_receipt/parser/comment_content_builder.rb
@@ -11,6 +11,7 @@ module Receiptisan
           # コメントの文字データを適切なオブジェクトにするビルダー
           class CommentContentBuilder
             include Master::Treatment::Comment::AppendedContent
+
             using Receiptisan::Util::WarekiExtension
 
             Formatter = Receiptisan::Util::Formatter
@@ -47,8 +48,12 @@ module Receiptisan
                 )
               end,
               Pattern::APPEND_WAREKI_NUMBER => proc do | wareki_and_number |
+                wareki_date = @@patterns[Pattern::APPEND_DIGITS].call(wareki_and_number[0, 7])
+                parsed_wareki_date = DateUtil.parse_date(Formatter.to_hankaku(wareki_and_number[0, 7]))
+
                 WarekiDateAndNumberFormat.new(
-                  @@patterns[Pattern::APPEND_DIGITS].call(wareki_and_number[0, 7]),
+                  wareki_date,
+                  parsed_wareki_date,
                   @@patterns[Pattern::APPEND_NUMBER].call(wareki_and_number[-8..])
                 )
               end,

--- a/lib/receiptisan/model/receipt_computer/master/treatment/comment.rb
+++ b/lib/receiptisan/model/receipt_computer/master/treatment/comment.rb
@@ -259,13 +259,19 @@ module Receiptisan
               #
               # パターン80
               class WarekiDateAndNumberFormat
-                def initialize(wareki_date_format, number_format)
-                  @wareki = wareki_date_format
-                  @number = number_format
+                using Receiptisan::Util::WarekiExtension
+
+                def initialize(wareki_date_format, wareki_date, number_format)
+                  @wareki_date_format = wareki_date_format
+                  @wareki_date = wareki_date
+                  @number_format = number_format
                 end
 
                 def to_s
-                  '%s%s' % [@wareki, @number]
+                  wareki = @wareki_date.to_wareki(zenkaku: true)
+                  number = Receiptisan::Util::Formatter.trim_leading_zero(@number_format.to_s)
+
+                  "#{wareki}　検査値：#{number}"
                 end
               end
 

--- a/lib/receiptisan/util/formatter.rb
+++ b/lib/receiptisan/util/formatter.rb
@@ -82,6 +82,17 @@ module Receiptisan
           .gsub('ｃｍ', '㎝')
           .gsub('ｎｍ', '㎚')
       end
+
+      # 先頭から始める全角ゼロを取り除く
+      #
+      # @param string [String]
+      # @return [String]
+      def trim_leading_zero(string)
+        trimmed = string.sub(/^０+/, '')
+        return '０' if trimmed.empty?
+
+        trimmed.start_with?('.') ? "０#{trimmed}" : trimmed
+      end
     end
   end
 end

--- a/spec/lib/receiptisan/model/receipt_computer/master/treatment/comment/appended_content/wareki_date_and_number_format_spec.rb
+++ b/spec/lib/receiptisan/model/receipt_computer/master/treatment/comment/appended_content/wareki_date_and_number_format_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rspec'
 require 'date'
 require 'receiptisan'
 require_relative 'appended_content_interface'
@@ -9,9 +10,10 @@ RSpec.describe Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::
     stub_const('AppendedContent', Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::AppendedContent)
   end
 
-  let(:wareki_date_format) { AppendedContent::WarekiDateFormat.new(_wareki = '５０４１２１３', _date = Date.new(2022, 12, 13)) }
-  let(:number_format)      { AppendedContent::NumberFormat.new('０１５０') }
-  let(:target)             { described_class.new(wareki_date_format, number_format) }
+  let(:wareki_to_date)     { Date.new(2022, 12, 13) }
+  let(:wareki_date_format) { AppendedContent::WarekiDateFormat.new(_wareki = '５０４１２１３', _date = wareki_to_date) }
+  let(:number_format) { AppendedContent::NumberFormat.new('００００００.７') }
+  let(:target) { described_class.new(wareki_date_format, wareki_to_date, number_format) }
 
   describe 'behave as appended content' do
     it_behaves_like 'appended_content_interface'
@@ -19,7 +21,37 @@ RSpec.describe Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::
 
   describe '#to_s' do
     specify '和暦年月日と数値をまとめた文字列を返す' do
-      expect(target.to_s).to eq '令和　４年１２月１３日０１５０'
+      expect(target.to_s).to eq '令和　４年１２月１３日　検査値：０.７'
+    end
+
+    context '検査値' do
+      specify '０が除かれた整数値が返ること' do
+        number_format = AppendedContent::NumberFormat.new('０００００１２３')
+        target = described_class.new(wareki_date_format, wareki_to_date, number_format)
+
+        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：１２３'
+      end
+
+      specify '０が除かれた小数値が返ること' do
+        number_format = AppendedContent::NumberFormat.new('０００１２３.４５')
+        target = described_class.new(wareki_date_format, wareki_to_date, number_format)
+
+        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：１２３.４５'
+      end
+
+      specify '０が返ること' do
+        number_format = AppendedContent::NumberFormat.new('００００００００')
+        target = described_class.new(wareki_date_format, wareki_to_date, number_format)
+
+        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：０'
+      end
+
+      specify '０埋めがない場合、整数値が返ること' do
+        number_format = AppendedContent::NumberFormat.new('１０００００００')
+        target = described_class.new(wareki_date_format, wareki_to_date, number_format)
+
+        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：１０００００００'
+      end
     end
   end
 end


### PR DESCRIPTION
## Why / 背景

問い合わせで発覚

https://henry-app.slack.com/archives/C079DBM32CS/p1766037832500269 

## What / 変更内容

- コメントパターン80の場合に、出力する結果を修正
  - $和暦；検査値：$数値 となるようにした

## 動作確認

**before**

<img width="726" height="469" alt="スクリーンショット 2025-12-18 133613" src="https://github.com/user-attachments/assets/f3ded3df-8c42-45cc-bdeb-66f9c5eab492" />


**after**

<img width="925" height="824" alt="スクリーンショット 2025-12-19 15 26 55" src="https://github.com/user-attachments/assets/f8309512-641a-4875-9075-ff2544f0ae52" />


---


<details>
<summary>Pull Request 作成者へ</summary>

Pull Request のレビューを依頼する際には、円滑なレビューを行うために以下を確認してください。

- アプリケーションコードへの変更の場合、[Release Plan](https://www.notion.so/henry-inc/cc805fd35aea4f5a9b08d515221dee51)を作成しましょう。
  - ただし、顧客案内も動作確認も不要と判断している場合は、リリースプランの作成は不要です。その判断も含めてレビューするため、判断内容をコメントに記載してください。
- 手元で動作確認を行い、問題がないことを確認しましょう。
- [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) を読みましょう。
- 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足しましょう。
- 既存のデータにどのような影響があるかを考慮し、必要があれば補足を記載しましょう。
- どのように動作確認をするか、チームで認識を揃えましょう。必要があれば、検討した内容を Pull Request から辿れるよう、転記やリンクの記載をしましょう。

</details>
