### PR TITLE
fix: 半角ピリオドに対して判定をとっている

### DIFF
--- a/lib/receiptisan/util/formatter.rb
+++ b/lib/receiptisan/util/formatter.rb
@@ -91,7 +91,7 @@ module Receiptisan
         trimmed = string.sub(/^０+/, '')
         return '０' if trimmed.empty?
 
-        trimmed.start_with?('.') ? "０#{trimmed}" : trimmed
+        trimmed.start_with?('．') ? "０#{trimmed}" : trimmed
       end
     end
   end

--- a/spec/lib/receiptisan/model/receipt_computer/master/treatment/comment/appended_content/wareki_date_and_number_format_spec.rb
+++ b/spec/lib/receiptisan/model/receipt_computer/master/treatment/comment/appended_content/wareki_date_and_number_format_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::
 
   let(:wareki_to_date)     { Date.new(2022, 12, 13) }
   let(:wareki_date_format) { AppendedContent::WarekiDateFormat.new(_wareki = '５０４１２１３', _date = wareki_to_date) }
-  let(:number_format) { AppendedContent::NumberFormat.new('００００００.７') }
+  let(:number_format) { AppendedContent::NumberFormat.new('００００００．７') }
   let(:target) { described_class.new(wareki_date_format, wareki_to_date, number_format) }
 
   describe 'behave as appended content' do
@@ -21,7 +21,7 @@ RSpec.describe Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::
 
   describe '#to_s' do
     specify '和暦年月日と数値をまとめた文字列を返す' do
-      expect(target.to_s).to eq '令和　４年１２月１３日　検査値：０.７'
+      expect(target.to_s).to eq '令和　４年１２月１３日　検査値：０．７'
     end
 
     context '検査値' do
@@ -33,10 +33,10 @@ RSpec.describe Receiptisan::Model::ReceiptComputer::Master::Treatment::Comment::
       end
 
       specify '０が除かれた小数値が返ること' do
-        number_format = AppendedContent::NumberFormat.new('０００１２３.４５')
+        number_format = AppendedContent::NumberFormat.new('０００１２３．４５')
         target = described_class.new(wareki_date_format, wareki_to_date, number_format)
 
-        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：１２３.４５'
+        expect(target.to_s).to eq '令和　４年１２月１３日　検査値：１２３．４５'
       end
 
       specify '０が返ること' do


### PR DESCRIPTION
## Why / 背景

レセプトプレビューにてコメント８０パターンが想定通り表示されない。
<img width="921" height="725" alt="スクリーンショット 2025-12-22 15 30 17" src="https://github.com/user-attachments/assets/737a81c0-885e-43b8-b151-fd9ac953e815" />


## What / 変更内容

正しくは全角ピリオドに対して判定を取る必要があった。

<img width="918" height="926" alt="スクリーンショット 2025-12-22 15 29 25" src="https://github.com/user-attachments/assets/52226c38-3b20-4253-9867-01a7b105f086" />

---


<details>
<summary>Pull Request 作成者へ</summary>

Pull Request のレビューを依頼する際には、円滑なレビューを行うために以下を確認してください。

- アプリケーションコードへの変更の場合、[Release Plan](https://www.notion.so/henry-inc/cc805fd35aea4f5a9b08d515221dee51)を作成しましょう。
  - ただし、顧客案内も動作確認も不要と判断している場合は、リリースプランの作成は不要です。その判断も含めてレビューするため、判断内容をコメントに記載してください。
- 手元で動作確認を行い、問題がないことを確認しましょう。
- [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) を読みましょう。
- 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足しましょう。
- 既存のデータにどのような影響があるかを考慮し、必要があれば補足を記載しましょう。
- どのように動作確認をするか、チームで認識を揃えましょう。必要があれば、検討した内容を Pull Request から辿れるよう、転記やリンクの記載をしましょう。

</details>
